### PR TITLE
fix single digit parameter indexes overlapping multiple-digit parameter indexes.

### DIFF
--- a/src/LINQPad.NHibernate.FormatSQL/NHibernateSqlOutputRedirector.cs
+++ b/src/LINQPad.NHibernate.FormatSQL/NHibernateSqlOutputRedirector.cs
@@ -70,7 +70,7 @@ namespace LINQPad.NHibernate.FormatSQL
                         {
                             newValue = "'" + newValue.Substring(1, newValue.Length - 2).Replace("'", "''") + "'";
                         }
-                        output = output.Replace(parameter.key, newValue);
+                        output = Regex.Replace(output, string.Format(@"{0}(?!\d)", parameter.key), newValue);
                     }
                 }
 


### PR DESCRIPTION
Queries with >10 parameters get replacement errors, for example and query with the following parameters:

'@p1 = "foo"'
'@p10 = "bar"'

and the (excerpt from) statement:

`WHERE [ColA] = '@p1'; ..... AND [ColB] = '@p10'`

Becomes:

`WHERE [ColA] = 'foo' .... AND [ColB] = 'foo0'`

This change ensures it does as expected and becomes

`WHERE [ColA] = 'foo' .... AND [ColB] = 'bar'`